### PR TITLE
syncing.go

### DIFF
--- a/pkg/rpc/syncing.go
+++ b/pkg/rpc/syncing.go
@@ -34,7 +34,7 @@ func (s *Syncing) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// Syncing - Returns an object about the sync status, or false if the node is not synching
+// Syncing - Returns an object about the sync status, or false if the node is not syncing
 func (api API) Syncing(ctx context.Context, opts ...RequestOption) (*Response[Syncing], error) {
 	request := api.prepareRequest("starknet_syncing", []any{}, opts...)
 


### PR DESCRIPTION
# Fix Typo in `syncing.go`

## Description
This pull request corrects a typo in the `syncing.go` file. The word "synching" was updated to "syncing" in the comment explaining the `Syncing` function.

### Changes Made:
- Updated the comment for the `Syncing` function to correct the spelling from "synching" to "syncing."

## Checklist
- [x] Verified that the typo correction improves clarity without altering functionality.
- [x]
